### PR TITLE
Use https instead of git:// for source url

### DIFF
--- a/language-c99-util.cabal
+++ b/language-c99-util.cabal
@@ -20,7 +20,7 @@ cabal-version:       >=1.10
 
 source-repository head
   type:     git
-  location: git://github.com:fdedden/language-c99-util.git
+  location: https://github.com/fdedden/language-c99-util.git
 
 library
   exposed-modules:   Language.C99.Util


### PR DESCRIPTION
`git://` is no longer supported.